### PR TITLE
Remove dead link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ The Talkdesk APIs are a way for you to connect and "sync" other applications (cu
 
 [Integrations API](https://github.com/Talkdesk/api/tree/master/integrations)
 
-## Help
-
-If you have questions that are related to the API chat with someone from tech support by acessing [our chat room](http://www.hipchat.com/gyjJEVCEE).
-
 ## Help Us Make it Better
 
 Please tell us how we can make Talkdesk APIs better. If you have a specific feature request or if you found a bug, please email us at [support@talkdesk.com](mailto: support@talkdesk.com).


### PR DESCRIPTION
Readme had a link to our old HipChat public room. Deleted this section as
we had received some customers trying to access it still.

closes #15