### PR TITLE
Add deprecated documentation header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The Talkdesk APIs are a way for you to connect and "sync" other applications (cu
 
 ## Help
 
-If you have questions that are related to the API chat with someone from tech support by accessing [support@talkdesk.com](mailto: support@talkdesk.com).
+If you have questions that are related to the API chat with someone from tech support by accessing [support@talkdesk.com](mailto:support@talkdesk.com).
 
 ## Help Us Make it Better
 
-Please tell us how we can make Talkdesk APIs better. If you have a specific feature request or if you found a bug, please email us at [support@talkdesk.com](mailto: support@talkdesk.com).
+Please tell us how we can make Talkdesk APIs better. If you have a specific feature request or if you found a bug, please email us at [support@talkdesk.com](mailto:support@talkdesk.com).
 
 Feel free to fork these docs and send a pull request with improvements!

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 # Integrations API
 
 Talkdesk Integrations API makes it easy for third-parties to send data to and from Talkdesk. The system is designed to work asynchronously through HTTP web-hooks. Third parties create their own integrations by providing Talkdesk a specific configuration and implementing their own bridges.

--- a/integrations/action-execution/README.md
+++ b/integrations/action-execution/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 # Implementing an Action Executor
 
 Talkdesk will execute a configured action on the bridge when a trigger of an automation where that action takes part happens on the system. Actions can also be executed from a request of a user with manually input data. An action execution request POST will send the following parameters.

--- a/integrations/agent-synchronization/README.md
+++ b/integrations/agent-synchronization/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 ## Implementing an Agent Retriever
 
 Talkdesk will send an HTTP POST to the bridge's endpoint when an agent synchronization is needed. The request is as follows:

--- a/integrations/auth-validation/README.md
+++ b/integrations/auth-validation/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 # Implementing an Authorization Validator
 
 When a user activates an integration for their Talkdesk account, a POST will be made to the configured endpoint with the user's

--- a/integrations/configuration/README.md
+++ b/integrations/configuration/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 # Configuring a Talkdesk Integration
 
 Talkdesk has to know a few things about your new integration: what it is called, what kind of authentication mechanism it needs, where it lives and which feature set it provides.

--- a/integrations/contact-synchronization/README.md
+++ b/integrations/contact-synchronization/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 # Implementing a Contact Retriever
 
 Talkdesk will send an HTTP POST to the bridge's configured endpoint when a contact synchronization is run. This request can be slightly different depending on the situation for which it is running:

--- a/integrations/interaction-update/README.md
+++ b/integrations/interaction-update/README.md
@@ -1,3 +1,5 @@
+**This documentation is no longer up to date - please refer to our current documentation at [https://docs.talkdesk.com/docs/integrations](https://docs.talkdesk.com/docs/integrations).**
+
 # Implementing an Interaction Retriever
 
 Talkdesk's interaction updater will send an HTTP POST request to the bridge in order to retrieve a contact's interactions with the external service whenever that contact is being displayed to a user. It passes along the following parameters:


### PR DESCRIPTION
This change adds a deprecated documentation header to all pages of the
repository. The purpose is to inform readers there are documentation
sources that are more accurate.

JIRA INT-1318